### PR TITLE
generalize asset id in standard amm

### DIFF
--- a/example/runtime/src/zenlink.rs
+++ b/example/runtime/src/zenlink.rs
@@ -13,7 +13,7 @@ use zenlink_vault::VaultAssetGenerate;
 parameter_types! {
 	pub SelfParaId: u32 = ParachainInfo::parachain_id().into();
 	pub const ZenlinkPalletId: PalletId = PalletId(*b"/zenlink");
-	pub ZenlinkRegistedParaChains: Vec<(MultiLocation, u128)> = vec![
+	pub ZenlinkRegisteredParaChains: Vec<(MultiLocation, u128)> = vec![
 		(make_x2_location(2001), 10_000_000_000),
 	];
 	pub const StringLimit: u32 = 50;
@@ -25,9 +25,12 @@ impl zenlink_protocol::Config for Runtime {
 	type Event = super::Event;
 	type MultiAssetsHandler = MultiAssets;
 	type PalletId = ZenlinkPalletId;
-	type TargetChains = ZenlinkRegistedParaChains;
+	type AssetId = AssetId;
+	type LpGenerate = PairLpGenerate<Self>;
+	type TargetChains = ZenlinkRegisteredParaChains;
 	type SelfParaId = SelfParaId;
-	type Conversion = ();
+	type AccountIdConverter = ();
+	type AssetIdConverter = AssetIdConverter;
 	type XcmExecutor = ();
 	type WeightInfo = ();
 }

--- a/zenlink-protocol/rpc/runtime-api/src/lib.rs
+++ b/zenlink-protocol/rpc/runtime-api/src/lib.rs
@@ -7,13 +7,14 @@
 
 use codec::Codec;
 use sp_std::vec::Vec;
-use zenlink_protocol::{AssetBalance, AssetId, PairInfo};
+use zenlink_protocol::{AssetBalance, PairInfo};
 
 sp_api::decl_runtime_apis! {
-	 pub trait ZenlinkProtocolApi<AccountId>
+	 pub trait ZenlinkProtocolApi<AccountId, AssetId>
 	 where
 		AccountId: Codec,
-		AssetBalance: Codec
+		AssetBalance: Codec,
+		AssetId: Codec
 	 {
 
 		fn get_balance(asset_id: AssetId, owner: AccountId) -> AssetBalance;
@@ -23,7 +24,7 @@ sp_api::decl_runtime_apis! {
 		fn get_pair_by_asset_id(
 			asset_0: AssetId,
 			asset_1: AssetId
-		) -> Option<PairInfo<AccountId, AssetBalance>>;
+		) -> Option<PairInfo<AccountId, AssetBalance, AssetId>>;
 
 		//buy amount asset price
 		fn get_amount_in_price(supply: AssetBalance, path: Vec<AssetId>) -> AssetBalance;

--- a/zenlink-protocol/src/fee/mock.rs
+++ b/zenlink-protocol/src/fee/mock.rs
@@ -27,8 +27,8 @@ use sp_runtime::{
 
 use crate as pallet_zenlink;
 pub use crate::{
-	AssetBalance, AssetId, Config, LocalAssetHandler, MultiAssetsHandler, Pallet, ParaId,
-	ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE, RESERVED,
+	AssetBalance, AssetId, AssetIdConverter, Config, LocalAssetHandler, MultiAssetsHandler,
+	PairLpGenerate, Pallet, ParaId, ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE, RESERVED,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -149,10 +149,13 @@ impl Config for Test {
 	type Event = Event;
 	type MultiAssetsHandler = ZenlinkMultiAssets<Zenlink, Balances, LocalAssetAdaptor<Tokens>>;
 	type PalletId = ZenlinkPalletId;
+	type AssetId = AssetId;
+	type LpGenerate = PairLpGenerate<Self>;
 	type TargetChains = ();
 	type SelfParaId = ();
 	type XcmExecutor = ();
-	type Conversion = ();
+	type AccountIdConverter = ();
+	type AssetIdConverter = AssetIdConverter;
 	type WeightInfo = ();
 }
 

--- a/zenlink-protocol/src/foreign/mock.rs
+++ b/zenlink-protocol/src/foreign/mock.rs
@@ -11,8 +11,8 @@ use sp_runtime::{
 
 use crate as pallet_zenlink;
 pub use crate::{
-	Config, MultiAssetsHandler, Pallet, ParaId, ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE,
-	RESERVED,
+	AssetId, AssetIdConverter, Config, MultiAssetsHandler, PairLpGenerate, Pallet, ParaId,
+	ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE, RESERVED,
 };
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -81,10 +81,13 @@ impl Config for Test {
 	type Event = Event;
 	type MultiAssetsHandler = ZenlinkMultiAssets<Zenlink, Balances>;
 	type PalletId = ZenlinkPalletId;
+	type AssetId = AssetId;
+	type LpGenerate = PairLpGenerate<Self>;
 	type TargetChains = ();
 	type SelfParaId = ();
 	type XcmExecutor = ();
-	type Conversion = ();
+	type AccountIdConverter = ();
+	type AssetIdConverter = AssetIdConverter;
 	type WeightInfo = ();
 }
 

--- a/zenlink-protocol/src/foreign/mod.rs
+++ b/zenlink-protocol/src/foreign/mod.rs
@@ -21,7 +21,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Implement of the transfer function.
 	pub(crate) fn foreign_transfer(
-		id: AssetId,
+		id: T::AssetId,
 		owner: &T::AccountId,
 		target: &T::AccountId,
 		amount: AssetBalance,
@@ -45,7 +45,7 @@ impl<T: Config> Pallet<T> {
 	/// Increase the total supply of the foreign
 	/// Note: no need check Exists, because it be created when it not exist
 	pub(crate) fn foreign_mint(
-		id: AssetId,
+		id: T::AssetId,
 		owner: &T::AccountId,
 		amount: AssetBalance,
 	) -> DispatchResult {
@@ -76,7 +76,7 @@ impl<T: Config> Pallet<T> {
 
 	/// Decrease the total supply of the foreign
 	pub(crate) fn foreign_burn(
-		id: AssetId,
+		id: T::AssetId,
 		owner: &T::AccountId,
 		amount: AssetBalance,
 	) -> DispatchResult {
@@ -100,16 +100,16 @@ impl<T: Config> Pallet<T> {
 	// Public immutable functions
 
 	/// Get the foreign `id` balance of `owner`.
-	pub fn foreign_balance_of(id: AssetId, owner: &T::AccountId) -> AssetBalance {
+	pub fn foreign_balance_of(id: T::AssetId, owner: &T::AccountId) -> AssetBalance {
 		Self::foreign_ledger((id, owner))
 	}
 
 	/// Get the total supply of an foreign `id`.
-	pub fn foreign_total_supply(id: AssetId) -> AssetBalance {
+	pub fn foreign_total_supply(id: T::AssetId) -> AssetBalance {
 		Self::foreign_meta(id)
 	}
 
-	pub fn foreign_is_exists(id: AssetId) -> bool {
+	pub fn foreign_is_exists(id: T::AssetId) -> bool {
 		Self::foreign_list().contains(&id)
 	}
 }

--- a/zenlink-protocol/src/multiassets.rs
+++ b/zenlink-protocol/src/multiassets.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-pub trait MultiAssetsHandler<AccountId> {
+pub trait MultiAssetsHandler<AccountId, AssetId: Copy> {
 	fn balance_of(asset_id: AssetId, who: &AccountId) -> AssetBalance;
 
 	fn total_supply(asset_id: AssetId) -> AssetBalance;
@@ -39,7 +39,8 @@ pub struct ZenlinkMultiAssets<T, Native = (), Local = (), Other = ()>(
 	PhantomData<(T, Native, Local, Other)>,
 );
 
-impl<T: Config, NativeCurrency, Local, Other> MultiAssetsHandler<T::AccountId>
+impl<T: Config<AssetId = AssetId>, NativeCurrency, Local, Other>
+	MultiAssetsHandler<T::AccountId, AssetId>
 	for ZenlinkMultiAssets<Pallet<T>, NativeCurrency, Local, Other>
 where
 	NativeCurrency: Currency<T::AccountId>,

--- a/zenlink-protocol/src/primitives.rs
+++ b/zenlink-protocol/src/primitives.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use scale_info::TypeInfo;
+use sp_std::marker::PhantomData;
 
 pub type AssetBalance = u128;
 
@@ -16,25 +17,81 @@ pub const LOCAL: u8 = 2;
 pub const RESERVED: u8 = 3;
 
 /// AssetId use to locate assets in framed base chain.
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo)]
+#[derive(
+	Encode,
+	Decode,
+	Eq,
+	PartialEq,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialOrd,
+	Ord,
+	TypeInfo,
+	MaxEncodedLen,
+)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Default))]
 pub struct AssetId {
+	/// Parachain ID
 	pub chain_id: u32,
+	/// Pallet ID
 	pub asset_type: u8,
+	/// Index of asset within that pallet
 	pub asset_index: u64,
 }
 
-impl AssetId {
-	pub fn is_support(&self) -> bool {
+pub trait AssetInfo {
+	fn is_support(&self) -> bool;
+}
+
+impl AssetInfo for AssetId {
+	fn is_support(&self) -> bool {
 		matches!(self.asset_type, NATIVE | LIQUIDITY | LOCAL | RESERVED)
 	}
+}
 
+impl AssetId {
 	pub fn is_native(&self, self_chain_id: u32) -> bool {
 		self.chain_id == self_chain_id && self.asset_type == NATIVE && self.asset_index == 0
 	}
 
 	pub fn is_foreign(&self, self_chain_id: u32) -> bool {
 		self.chain_id != self_chain_id
+	}
+}
+
+pub struct PairLpGenerate<T>(PhantomData<T>);
+impl<T: Config> GenerateLpAssetId<AssetId> for PairLpGenerate<T> {
+	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> AssetId {
+		let currency_0 = (asset_0.asset_index & 0x0000_0000_0000_ffff) << 16;
+		let currency_1 = (asset_1.asset_index & 0x0000_0000_0000_ffff) << 32;
+		let discr = 6u64 << 8;
+		let index = currency_0 + currency_1 + discr;
+		AssetId { chain_id: T::SelfParaId::get(), asset_type: LOCAL, asset_index: index }
+	}
+}
+
+impl Into<MultiLocation> for AssetId {
+	fn into(self) -> MultiLocation {
+		MultiLocation::new(
+			1,
+			Junctions::X3(
+				Junction::Parachain(self.chain_id),
+				Junction::PalletInstance(self.asset_type),
+				Junction::GeneralIndex { 0: self.asset_index as u128 },
+			),
+		)
+	}
+}
+
+pub struct AssetIdConverter;
+impl ConvertMultiLocation<AssetId> for AssetIdConverter {
+	fn chain_id(asset_id: &AssetId) -> u32 {
+		asset_id.chain_id
+	}
+
+	fn make_x3_location(asset_id: &AssetId) -> MultiLocation {
+		asset_id.clone().into()
 	}
 }
 

--- a/zenlink-protocol/src/swap/mock.rs
+++ b/zenlink-protocol/src/swap/mock.rs
@@ -26,8 +26,8 @@ use sp_runtime::{
 
 use crate as pallet_zenlink;
 pub use crate::{
-	AssetBalance, AssetId, Config, LocalAssetHandler, MultiAssetsHandler, Pallet, ParaId,
-	ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE, RESERVED,
+	AssetBalance, AssetId, AssetIdConverter, Config, LocalAssetHandler, MultiAssetsHandler,
+	PairLpGenerate, Pallet, ParaId, ZenlinkMultiAssets, LIQUIDITY, LOCAL, NATIVE, RESERVED,
 };
 use orml_traits::{parameter_type_with_key, MultiCurrency};
 
@@ -149,10 +149,13 @@ impl Config for Test {
 	type Event = Event;
 	type MultiAssetsHandler = ZenlinkMultiAssets<Zenlink, Balances, LocalAssetAdaptor<Tokens>>;
 	type PalletId = ZenlinkPalletId;
+	type AssetId = AssetId;
+	type LpGenerate = PairLpGenerate<Self>;
 	type TargetChains = ();
 	type SelfParaId = ();
 	type XcmExecutor = ();
-	type Conversion = ();
+	type AccountIdConverter = ();
+	type AssetIdConverter = AssetIdConverter;
 	type WeightInfo = ();
 }
 

--- a/zenlink-protocol/src/traits.rs
+++ b/zenlink-protocol/src/traits.rs
@@ -3,6 +3,20 @@
 
 use super::*;
 
+pub trait GenerateLpAssetId<AssetId> {
+	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> AssetId;
+}
+
+pub trait ConvertMultiLocation<AssetId> {
+	fn chain_id(asset_id: &AssetId) -> u32;
+
+	fn make_x2_location(asset_id: &AssetId) -> MultiLocation {
+		MultiLocation::new(1, Junctions::X1(Junction::Parachain(Self::chain_id(asset_id))))
+	}
+
+	fn make_x3_location(asset_id: &AssetId) -> MultiLocation;
+}
+
 pub trait LocalAssetHandler<AccountId> {
 	fn local_balance_of(asset_id: AssetId, who: &AccountId) -> AssetBalance;
 
@@ -127,7 +141,7 @@ impl<AccountId> OtherAssetHandler<AccountId> for () {
 	}
 }
 
-pub trait ExportZenlink<AccountId> {
+pub trait ExportZenlink<AccountId, AssetId> {
 	fn get_amount_in_by_path(
 		amount_out: AssetBalance,
 		path: &[AssetId],

--- a/zenlink-swap-router/src/lib.rs
+++ b/zenlink-swap-router/src/lib.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 			+ TypeInfo
 			+ MaxEncodedLen;
 
-		type NormalAmm: ExportZenlink<AccountIdOf<Self>>;
+		type NormalAmm: ExportZenlink<AccountIdOf<Self>, AssetId>;
 
 		type StableAMM: StableAmmApi<
 			Self::StablePoolId,

--- a/zenlink-swap-router/src/mock.rs
+++ b/zenlink-swap-router/src/mock.rs
@@ -25,7 +25,10 @@ use sp_runtime::{
 use crate as router;
 use crate::{Config, Pallet};
 use orml_traits::{parameter_type_with_key, MultiCurrency};
-use zenlink_protocol::{AssetBalance, AssetId, LocalAssetHandler, ZenlinkMultiAssets, LOCAL};
+use zenlink_protocol::{
+	AssetBalance, AssetId, AssetIdConverter, LocalAssetHandler, PairLpGenerate, ZenlinkMultiAssets,
+	LOCAL,
+};
 use zenlink_stable_amm::traits::{StablePoolLpCurrencyIdGenerate, ValidateCurrency};
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -210,10 +213,13 @@ impl zenlink_protocol::Config for Test {
 	type Event = Event;
 	type MultiAssetsHandler = ZenlinkMultiAssets<Zenlink, Balances, LocalAssetAdaptor<Tokens>>;
 	type PalletId = ZenlinkPalletId;
+	type AssetId = AssetId;
+	type LpGenerate = PairLpGenerate<Self>;
 	type TargetChains = ();
 	type SelfParaId = SelfParaId;
 	type XcmExecutor = ();
-	type Conversion = ();
+	type AccountIdConverter = ();
+	type AssetIdConverter = AssetIdConverter;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Allows the consumer to use any `AssetId` when instantiating the "standard" AMM. In my case I would like to directly use the `CurrencyId` instead of converting to and from `zenlink_protocol::AssetId` since we anyway will have XCM disabled (see [this comment](https://github.com/zenlinkpro/Zenlink-DEX-Module/issues/36#issuecomment-1237799548)). The important thing to note is that this PR does not introduce any functional changes since the consumer may still use the concrete `AssetId` type and `PairLpGenerate`.