### PR TITLE
standard generate_lp_asset_id trait should be fallible

### DIFF
--- a/zenlink-protocol/src/lib.rs
+++ b/zenlink-protocol/src/lib.rs
@@ -653,7 +653,7 @@ pub mod pallet {
 				},
 			})?;
 
-			Self::mutate_lp_pairs(asset_0, asset_1);
+			Self::mutate_lp_pairs(asset_0, asset_1)?;
 
 			Self::deposit_event(Event::PairCreated(asset_0, asset_1));
 			Ok(())
@@ -1004,7 +1004,7 @@ pub mod pallet {
 			asset_1: T::AssetId,
 		) -> DispatchResult {
 			ensure_signed(origin)?;
-			Self::mutate_lp_pairs(asset_0, asset_1);
+			Self::mutate_lp_pairs(asset_0, asset_1)?;
 
 			Self::do_end_bootstrap(asset_0, asset_1)
 		}

--- a/zenlink-protocol/src/primitives.rs
+++ b/zenlink-protocol/src/primitives.rs
@@ -62,12 +62,12 @@ impl AssetId {
 
 pub struct PairLpGenerate<T>(PhantomData<T>);
 impl<T: Config> GenerateLpAssetId<AssetId> for PairLpGenerate<T> {
-	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> AssetId {
+	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> Option<AssetId> {
 		let currency_0 = (asset_0.asset_index & 0x0000_0000_0000_ffff) << 16;
 		let currency_1 = (asset_1.asset_index & 0x0000_0000_0000_ffff) << 32;
 		let discr = 6u64 << 8;
 		let index = currency_0 + currency_1 + discr;
-		AssetId { chain_id: T::SelfParaId::get(), asset_type: LOCAL, asset_index: index }
+		Some(AssetId { chain_id: T::SelfParaId::get(), asset_type: LOCAL, asset_index: index })
 	}
 }
 

--- a/zenlink-protocol/src/rpc.rs
+++ b/zenlink-protocol/src/rpc.rs
@@ -79,7 +79,7 @@ impl<T: Config> Pallet<T> {
 		asset_1: T::AssetId,
 	) -> Option<PairInfo<T::AccountId, AssetBalance, T::AssetId>> {
 		let pair_account = Self::pair_account_id(asset_0, asset_1);
-		let lp_asset_id = Self::lp_asset_id(&asset_0, &asset_1);
+		let lp_asset_id = Self::lp_asset_id(&asset_0, &asset_1)?;
 
 		let status = match Self::pair_status(Self::sort_asset_id(asset_0, asset_1)) {
 			Trading(_) => 0,

--- a/zenlink-protocol/src/swap/mod.rs
+++ b/zenlink-protocol/src/swap/mod.rs
@@ -39,14 +39,14 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
-	pub(crate) fn mutate_lp_pairs(asset_0: T::AssetId, asset_1: T::AssetId) {
-		LiquidityPairs::<T>::insert(
+	pub(crate) fn mutate_lp_pairs(asset_0: T::AssetId, asset_1: T::AssetId) -> DispatchResult {
+		Ok(LiquidityPairs::<T>::insert(
 			Self::sort_asset_id(asset_0, asset_1),
-			Some(Self::lp_asset_id(&asset_0, &asset_1)),
-		)
+			Some(Self::lp_asset_id(&asset_0, &asset_1).ok_or(Error::<T>::AssetNotExists)?),
+		))
 	}
 
-	pub fn lp_asset_id(asset_0: &T::AssetId, asset_1: &T::AssetId) -> T::AssetId {
+	pub fn lp_asset_id(asset_0: &T::AssetId, asset_1: &T::AssetId) -> Option<T::AssetId> {
 		let (asset_0, asset_1) = Self::sort_asset_id(*asset_0, *asset_1);
 		T::LpGenerate::generate_lp_asset_id(asset_0, asset_1)
 	}

--- a/zenlink-protocol/src/traits.rs
+++ b/zenlink-protocol/src/traits.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 pub trait GenerateLpAssetId<AssetId> {
-	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> AssetId;
+	fn generate_lp_asset_id(asset_0: AssetId, asset_1: AssetId) -> Option<AssetId>;
 }
 
 pub trait ConvertMultiLocation<AssetId> {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

It may not be possible to construct the LP asset ID with the change introduced here: https://github.com/zenlinkpro/Zenlink-DEX-Module/pull/46