### PR TITLE
ensure all meta amounts are given for adding base and meta liquidity

### DIFF
--- a/zenlink-stable-amm/src/lib.rs
+++ b/zenlink-stable-amm/src/lib.rs
@@ -1267,6 +1267,7 @@ impl<T: Config> Pallet<T> {
 
 		let base_pool_lp_currency = base_pool.get_lp_currency();
 		let meta_pool_currencies = meta_pool.get_currency_ids();
+		ensure!(meta_amounts.len() == meta_pool_currencies.len(), Error::<T>::MismatchParameter);
 
 		let mut deposit_base = false;
 		for amount in base_amounts.iter() {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

The code will panic below if `meta_amounts.len() < meta_pool_currencies.len()`.